### PR TITLE
UnmanagedImage.cs GetPixel() returned error message param returns incorrect param

### DIFF
--- a/Sources/Accord.Imaging/AForge.Imaging/UnmanagedImage.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/UnmanagedImage.cs
@@ -994,12 +994,12 @@ namespace Accord.Imaging
         /// 
         public Color GetPixel(int x, int y)
         {
-            if ((x < 0) || (y < 0))
+            if ((x < 0) || (x >= width))
             {
                 throw new ArgumentOutOfRangeException("x", "The specified pixel coordinate is out of image's bounds.");
             }
 
-            if ((x >= width) || (y >= height))
+            if ((y < 0) || (y >= height))
             {
                 throw new ArgumentOutOfRangeException("y", "The specified pixel coordinate is out of image's bounds.");
             }


### PR DESCRIPTION
Fix the returned error message so the correct param is returned for GetPixel(). Currently "x" is always returned for < 0 and "y" is always returned for >= Height or Width.

This probably also wants to be merged into the development branch.